### PR TITLE
修改gzip配置项

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -4,7 +4,7 @@ namespace Yurun\Proxy;
 class Server extends Base
 {
 	private $httpServer;
-	
+
 	private $listenServer;
 
 	private $parser;
@@ -22,6 +22,7 @@ class Server extends Base
 
 		$this->httpServer->set([
 			'upload_tmp_dir'	=>	'/' === substr(static::$option['upload_tmp_dir'], 0, 1) ? static::$option['upload_tmp_dir'] : dirname(__DIR__) . '/' . static::$option['upload_tmp_dir'],
+			'http_gzip_level' => 5,
 		]);
 
 		$this->httpServer->on('request', function($request, $response){

--- a/src/ServerUser.php
+++ b/src/ServerUser.php
@@ -14,7 +14,7 @@ class ServerUser
 	public $domain;
 
 	public $requests = [];
-	
+
 	public function __construct($fd, $httpServer)
 	{
 		$this->fd = $fd;
@@ -85,10 +85,6 @@ class ServerUser
 					{
 						$response->header($name, $value);
 					}
-				}
-				if(isset($data['data']['header']['Content-Encoding']))
-				{
-					$response->gzip(5);
 				}
 				$response->end(gzuncompress(base64_decode($data['data']['response'])));
 			}


### PR DESCRIPTION
swoole_http_response->gzip(int $level = 1)在4.1.0或更高版本中已废弃，在高版本swoole中使用该应用在产生致命错误Call to undefined method swoole_http_response::gzip()，修改后已在swoole4.3.5测试通过。详见https://wiki.swoole.com/wiki/page/973.html。